### PR TITLE
Update HH-of-T3.sage

### DIFF
--- a/HH-of-T3.sage
+++ b/HH-of-T3.sage
@@ -99,9 +99,16 @@ def try_all_conjugacy_classes(gamma,n,take_coinvariants=True):
     # compute dimensions
     for co in cokernels:
         co['dim'] = co['homology'].cardinality()
-        co['torsion_dim'] = sum(co['homology'].invariants())
+        co['torsion_dim'] = max(1,sum(co['homology'].invariants()))
     return cokernels
     #blablabla
+
+def dim_skeinmod(gamma,n):
+    cokernels = try_all_conjugacy_classes(gamma,n,take_coinvariants=True)
+    sum = 0
+    for co in cokernels:
+        sum += co['torsion_dim']
+    return sum
 
 def change_ring(module,R=QQ):
     """


### PR DESCRIPTION
added dim_skeinmod(gamma,n) and
in try_all_conjugacy_classes,  in the "counting dimensions part", when there is no torsion, it corresponds to the trivial group so when counting it should return 1 instead of 0 as was the case before.